### PR TITLE
Add documentation on how to create executable jar file (Issue #3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,20 +15,20 @@ A sample set of images are provided in an __"images"__ directory.
 
 ## Creating an executable jar file
 The project is already set up using the gradle wrapper so we can just use that to create the jar file.
-1. Open up the CLI and change the directory to the projects root directory.
+1. Using the command line interface, change to the project's root directory.
 2. Execute the command `./gradlew build`
 3. This will build/rebuild the jar file using all the required dependencies.
-4. The new jar file will be named "imagelab.jar" and it will be located in the projects root directory.
+4. The new jar file will be named "imagelab.jar" and it will be located in the project's root directory.
 
 More information on gradle can be found [here](https://docs.gradle.org/current/userguide/userguide.html) and more information on the gradle wrapper can be found [here](https://docs.gradle.org/current/userguide/gradle_wrapper.html).
 
 If there is no automated build environment set up, the jar file can be created using `jar`.
-1. Open up the CLI and change the directory to the projects root directory.
+1. Using the command line interface, change to the project's root directory.
 2. Execute the command `javac Run.java` to compile the Run.java file.
 3. Execute the command `javac *.java` in the package directories to compile/recompile those package java files. The package directories for this project will be the sound and imagelab directories.
 4. In the root directory execute the command `echo Main-Class: Run > MANIFEST.MF` to create the manifest file you will use for making the jar.
-5. Create the jar using the command `jar cfm DESIRED_FILENAME.jar MANIFEST.MF *.class sound/*.class imagelab/*.class`
-6. The new jar file will retain the name you gave it and will be located in the projects root directory.
+5. Create the jar using the command `jar cfm imagelab.jar MANIFEST.MF *.class sound/*.class imagelab/*.class`
+6. The new jar file will be named "imagelab.jar" and it will be located in the project's root directory.
 
 More information on creating the jar can be found [here](https://docs.oracle.com/javase/tutorial/deployment/jar/build.html) and more information about java commands can be found [here.](https://docs.oracle.com/en/java/javase/15/docs/specs/man/index.html)
 

--- a/README.md
+++ b/README.md
@@ -14,21 +14,19 @@ The __filter__ package is generally provided as a folder with source (`.java`) a
 A sample set of images are provided in an __"images"__ directory.
 
 ## Creating an executable jar file
-Instructions may vary depending on the IDE but in general the process will be similar to these instructions.
+Project is already set up using the gradle build environment so we can just use that to create the jar file.
+1. Open up the CLI and change the directory to the projects root directory.
+2. Execute the command "gradle build"
+3. This will build/rebuild the jar file using all the required dependencies.
 
-1. Open up the java files from this repository in your desired IDE. These will be found in the **sound, filters and imagelab** folders. Don't forget to also open up the **Run.java** from the base directory of the project. 
-2. Compile all of the java files.
-3. Navigate your IDE to find its *create jar* functionality.
-4. Set up the dependencies of the jar to use all of the files except for the **Run.java**.
-5. It should now give you an option to select the main class. The main class for this project is Run, so select Run as the main class.
-6. Choose a name for your jar to be saved under. Make sure to save your jar file in base directory of your imagelab repository.
-
-Some specific examples from popular IDE's can be found here:
+The executable jar file can also be created straight from an IDE, some specific examples from popular IDE's can be found here:
 - [Eclipse](https://support.smartbear.com/alertsite/docs/monitors/web/selenium/export-eclipse-java-project-as-runnable-jar.html)
 - [JDeveloper](https://www.albinsblog.com/2014/12/building-executable-jar-file-with.html)
 - [IntelliJ](https://www.jetbrains.com/help/idea/compiling-applications.html#package_into_jar)
 - [BlueJ](https://bluej.org/tutorial/tutorial-v4.pdf)
 - [NetBeans](https://netbeans.org/kb/articles/javase-deploy.html)
+- [VS Code](https://code.visualstudio.com/docs/java/java-project)
+- [DRJava](http://drjava.org/index.php?page=docs/user/ch04.html)
 
 ## To use from command line:  
 * Make sure the __filters__ directory is _in the same directory_ as the __imagelab.jar__ file.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,19 @@ The __filter__ package is generally provided as a folder with source (`.java`) a
 
 A sample set of images are provided in an __"images"__ directory.
 
+## Creating an executable jar file
+Make sure you have BlueJ installed on your device. Installation instructions can be found on the [BlueJ website](https://bluej.org/index.html) under the "Download and Install" header.
+
+1. Open up BlueJ on your device.
+2. Click the **project** tab and select *open project*.
+3. Find the base directory for your imagelab repository. If you are using git this is the directory you created for your clone of the repository.
+4. Select the directory and click *open*, this should open up the directory with BlueJ.
+5. Open up the different classes and click the *compile* option under the **tools** tab. Do this for each class so you can compile everything.
+6. With this done you can now click the **project** tab and select *create jar file*.
+7. It should now give you an option to select the main class. The main class for this project is Run, so select Run and click *continue*.
+8. Choose a name for your jar to be saved under. Make sure to save your jar file in base directory of your imagelab repository.
+
+
 ## To use from command line:  
 * Make sure the __filters__ directory is _in the same directory_ as the __imagelab.jar__ file.
 * Then issue the command  

--- a/README.md
+++ b/README.md
@@ -14,25 +14,25 @@ The __filter__ package is generally provided as a folder with source (`.java`) a
 A sample set of images are provided in an __"images"__ directory.
 
 ## Creating an executable jar file
-If there is no automated build environment set up, the jar file can be created using "jar."
+The project is already set up using the gradle wrapper so we can just use that to create the jar file.
 1. Open up the CLI and change the directory to the projects root directory.
-2. Execute the command "javac Run.java" to compile the Run.java file.
-3. Execute the command "javac \*.java" in the package directories to compile/recompile the java files.
-4. In the root directory execute the command "echo Main-Class: Run > MANIFEST.MF" to create a manifest file you will use later.
-5. Create the jar using the command "jar cfm (DESIRED_FILENAME.jar) MANIFEST.MF \*.class sound/\*.class imagelab/\*.class filters/\*.class"
-6. The new jar file will be named whatever you set it to and it will be located in the projects root directory.
-
-More info on the java commands can be found [here](https://docs.oracle.com/javase/tutorial/deployment/jar/build.html).
-
-However, the project is already set up using the gradle build environment and gradle wrapper so we can just use those to create the jar file.
-1. Open up the CLI and change the directory to the projects root directory.
-2. Execute the command "gradle build" or "./gradlew build"
+2. Execute the command `./gradlew build`
 3. This will build/rebuild the jar file using all the required dependencies.
 4. The new jar file will be named "imagelab.jar" and it will be located in the projects root directory.
 
-More info on gradle can be found [here](https://docs.gradle.org/current/userguide/userguide.html) and more info on the gradle wrapper can be found [here](https://docs.gradle.org/current/userguide/gradle_wrapper.html).
+More information on gradle can be found [here](https://docs.gradle.org/current/userguide/userguide.html) and more information on the gradle wrapper can be found [here](https://docs.gradle.org/current/userguide/gradle_wrapper.html).
 
-The executable jar file can also be created straight from an IDE, some specific examples from popular IDE's can be found here:
+If there is no automated build environment set up, the jar file can be created using `jar`.
+1. Open up the CLI and change the directory to the projects root directory.
+2. Execute the command `javac Run.java` to compile the Run.java file.
+3. Execute the command `javac \*.java` in the package directories to compile/recompile those package java files. The package directories for this project will be the sound and imagelab directories.
+4. In the root directory execute the command `echo Main-Class: Run > MANIFEST.MF` to create the manifest file you will use for making the jar.
+5. Create the jar using the command `jar cfm DESIRED_FILENAME.jar MANIFEST.MF *.class sound/*.class imagelab/*.class`
+6. The new jar file will retain the name you gave it and will be located in the projects root directory.
+
+More information on creating the jar can be found [here](https://docs.oracle.com/javase/tutorial/deployment/jar/build.html) and more information about java commands can be found [here.](https://docs.oracle.com/en/java/javase/15/docs/specs/man/index.html)
+
+The executable jar file can also be created within an IDE. Some specific examples from popular IDE's can be found here:
 - [Eclipse](https://support.smartbear.com/alertsite/docs/monitors/web/selenium/export-eclipse-java-project-as-runnable-jar.html)
 - [JDeveloper](https://www.albinsblog.com/2014/12/building-executable-jar-file-with.html)
 - [IntelliJ](https://www.jetbrains.com/help/idea/compiling-applications.html#package_into_jar)

--- a/README.md
+++ b/README.md
@@ -16,9 +16,11 @@ A sample set of images are provided in an __"images"__ directory.
 ## Creating an executable jar file
 If there is no automated build environment set up, the jar file can be created using "jar."
 1. Open up the CLI and change the directory to the projects root directory.
-2. Execute the command "echo Main-Class: Run > MANIFEST.MF" to create a manifest file you will use later.
-3. Create the jar using the command "jar cfm (DESIRED_FILENAME.jar) MANIFEST.MF \*.class sound/\*.class imagelab/\*.class filters/\*.class"
-4. The new jar file will be named whatever you set it to and it will be located in the projects root directory.
+2. Execute the command "javac Run.java" to compile the Run.java file.
+3. Execute the command "javac \*.java" in the package directories to compile/recompile the java files.
+4. In the root directory execute the command "echo Main-Class: Run > MANIFEST.MF" to create a manifest file you will use later.
+5. Create the jar using the command "jar cfm (DESIRED_FILENAME.jar) MANIFEST.MF \*.class sound/\*.class imagelab/\*.class filters/\*.class"
+6. The new jar file will be named whatever you set it to and it will be located in the projects root directory.
 
 More info on the java commands can be found [here](https://docs.oracle.com/javase/tutorial/deployment/jar/build.html).
 

--- a/README.md
+++ b/README.md
@@ -14,17 +14,21 @@ The __filter__ package is generally provided as a folder with source (`.java`) a
 A sample set of images are provided in an __"images"__ directory.
 
 ## Creating an executable jar file
-Make sure you have BlueJ installed on your device. Installation instructions can be found on the [BlueJ website](https://bluej.org/index.html) under the "Download and Install" header.
+Instructions may vary depending on the IDE but in general the process will be similar to these instructions.
 
-1. Open up BlueJ on your device.
-2. Click the **project** tab and select *open project*.
-3. Find the base directory for your imagelab repository. If you are using git this is the directory you created for your clone of the repository.
-4. Select the directory and click *open*, this should open up the directory with BlueJ.
-5. Open up the different classes and click the *compile* option under the **tools** tab. Do this for each class so you can compile everything.
-6. With this done you can now click the **project** tab and select *create jar file*.
-7. It should now give you an option to select the main class. The main class for this project is Run, so select Run and click *continue*.
-8. Choose a name for your jar to be saved under. Make sure to save your jar file in base directory of your imagelab repository.
+1. Open up the java files from this repository in your desired IDE. These will be found in the **sound, filters and imagelab** folders. Don't forget to also open up the **Run.java** from the base directory of the project. 
+2. Compile all of the java files.
+3. Navigate your IDE to find its *create jar* functionality.
+4. Set up the dependencies of the jar to use all of the files except for the **Run.java**.
+5. It should now give you an option to select the main class. The main class for this project is Run, so select Run as the main class.
+6. Choose a name for your jar to be saved under. Make sure to save your jar file in base directory of your imagelab repository.
 
+Some specific examples from popular IDE's can be found here:
+- [Eclipse](https://support.smartbear.com/alertsite/docs/monitors/web/selenium/export-eclipse-java-project-as-runnable-jar.html)
+- [JDeveloper](https://www.albinsblog.com/2014/12/building-executable-jar-file-with.html)
+- [IntelliJ](https://www.jetbrains.com/help/idea/compiling-applications.html#package_into_jar)
+- [BlueJ](https://bluej.org/tutorial/tutorial-v4.pdf)
+- [NetBeans](https://netbeans.org/kb/articles/javase-deploy.html)
 
 ## To use from command line:  
 * Make sure the __filters__ directory is _in the same directory_ as the __imagelab.jar__ file.

--- a/README.md
+++ b/README.md
@@ -14,10 +14,21 @@ The __filter__ package is generally provided as a folder with source (`.java`) a
 A sample set of images are provided in an __"images"__ directory.
 
 ## Creating an executable jar file
-Project is already set up using the gradle build environment so we can just use that to create the jar file.
+If there is no automated build environment set up, the jar file can be created using "jar."
 1. Open up the CLI and change the directory to the projects root directory.
-2. Execute the command "gradle build"
+2. Execute the command "echo Main-Class: Run > MANIFEST.MF" to create a manifest file you will use later.
+3. Create the jar using the command "jar cfm (DESIRED_FILENAME.jar) MANIFEST.MF \*.class sound/\*.class imagelab/\*.class filters/\*.class"
+4. The new jar file will be named whatever you set it to and it will be located in the projects root directory.
+
+More info on the java commands can be found [here](https://docs.oracle.com/javase/tutorial/deployment/jar/build.html).
+
+However, the project is already set up using the gradle build environment and gradle wrapper so we can just use those to create the jar file.
+1. Open up the CLI and change the directory to the projects root directory.
+2. Execute the command "gradle build" or "./gradlew build"
 3. This will build/rebuild the jar file using all the required dependencies.
+4. The new jar file will be named "imagelab.jar" and it will be located in the projects root directory.
+
+More info on gradle can be found [here](https://docs.gradle.org/current/userguide/userguide.html) and more info on the gradle wrapper can be found [here](https://docs.gradle.org/current/userguide/gradle_wrapper.html).
 
 The executable jar file can also be created straight from an IDE, some specific examples from popular IDE's can be found here:
 - [Eclipse](https://support.smartbear.com/alertsite/docs/monitors/web/selenium/export-eclipse-java-project-as-runnable-jar.html)

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ More information on gradle can be found [here](https://docs.gradle.org/current/u
 If there is no automated build environment set up, the jar file can be created using `jar`.
 1. Open up the CLI and change the directory to the projects root directory.
 2. Execute the command `javac Run.java` to compile the Run.java file.
-3. Execute the command `javac \*.java` in the package directories to compile/recompile those package java files. The package directories for this project will be the sound and imagelab directories.
+3. Execute the command `javac *.java` in the package directories to compile/recompile those package java files. The package directories for this project will be the sound and imagelab directories.
 4. In the root directory execute the command `echo Main-Class: Run > MANIFEST.MF` to create the manifest file you will use for making the jar.
 5. Create the jar using the command `jar cfm DESIRED_FILENAME.jar MANIFEST.MF *.class sound/*.class imagelab/*.class`
 6. The new jar file will retain the name you gave it and will be located in the projects root directory.


### PR DESCRIPTION
Added instructions for how to create an executable jar file to the README.md which should resolve the [user story from issue #3](https://github.com/MetroCS/imagelab/issues/3).