### PR TITLE
Update build file to run and report results of JUnit4 tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,8 @@ repositories {
 }
 
 dependencies {
+    implementation 'junit:junit:4.12'
+
     // These dependencies are used by the application.
     // implementation 'com.google.guava:guava:28.0-jre'
 
@@ -36,6 +38,12 @@ dependencies {
 // Add source code directories
 sourceSets {
     main {
+        java {
+            srcDirs('imagelab','filters','sound',"${project.projectDir}")
+        }
+    }
+    
+    test {
         java {
             srcDirs('imagelab','filters','sound',"${project.projectDir}")
         }
@@ -57,7 +65,10 @@ jar {
     }
 }
 
-
+test {
+    useJUnit()
+    reports.html.destination = file("$buildDir/reports/JUnit")
+}
 
 // Define jacoco version to be used
 jacoco {

--- a/imagelab/ImgProviderTest.java
+++ b/imagelab/ImgProviderTest.java
@@ -1,0 +1,38 @@
+package imagelab;
+
+import org.junit.Before;
+import org.junit.After;
+import org.junit.Test;
+import static org.junit.Assert.assertNotEquals;
+
+public class ImgProviderTest {
+    /**
+     * Sets up the test fixture.
+     * (Called before every test case method.)
+     */
+    @Before
+    public void setUp() {
+    }
+
+    /**
+     * Tears down the test fixture.
+     * (Called after every test case method.)
+     */
+    @After
+    public void tearDown() {
+    }
+
+    /**
+     * Each instance of an ImgProvider should have its own unique ID attribute.
+     */
+    @Test
+    public void constructorShouldAssignUniqueIDs() {
+        ImgProvider provider1 = new ImgProvider();
+        ImgProvider provider2 = new ImgProvider();
+        ImgProvider provider3 = new ImgProvider();
+
+        assertNotEquals(provider1.getid(), provider2.getid());
+        assertNotEquals(provider2.getid(), provider3.getid());
+        assertNotEquals(provider1.getid(), provider3.getid());
+    }
+}


### PR DESCRIPTION
This PR addresses issue #44 
Acceptance Criteria:
* There should be an obvious location in the project's directory structure for unit test files
  * This location should be consistent with the file/directory structure of a BlueJ project
_Placing the newly created ImgProviderTest.java alongside its corresponding class in the imagelab package directory is both consistent with BlueJ's directory structure, and signals to future contributors that this is the convention to follow when creating unit test classes._
* The `gradlew test` command should build and run any JUnit4 tests that are in the above location
_This functionality now exists under this PR. Additionally, `gradlew build` also builds and runs the test suite_
* The test report should be saved somewhere in the build/reports directory
_The test report is saved at `build/reports/JUnit/index.html`_
* There should be at least one meaningful unit test present in the designated directory, so that the above can be verified
_As mentioned above, the ImgProviderTest class has been created, and it contains a meaningful test of ImgProvider's unique id assignment._